### PR TITLE
"irrevelant" to "irrelevant"

### DIFF
--- a/doc/treemethod.rst
+++ b/doc/treemethod.rst
@@ -10,7 +10,7 @@ are also some free standing updaters including ``grow_local_histmaker``, ``refre
 as the latter is just a pre-configuration of the former.  The difference is mostly due to
 historical reasons that each updater requires some specific configurations and might has
 missing features.  As we are moving forward, the gap between them is becoming more and
-more irrevelant.  We will collectively document them under tree methods.
+more irrelevant.  We will collectively document them under tree methods.
 
 **************
 Exact Solution


### PR DESCRIPTION
As we are moving forward, the gap between them is becoming more and more "irrevelant". I guess "irrevelant" should be "irrelevant"